### PR TITLE
remove title attribute

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,3 +1,2 @@
 name: tutorials
-title: Tutorial Template
 version: 'master'


### PR DESCRIPTION
The title is already set in the `tutorials` repository. From my experience, it should be set once.